### PR TITLE
Delete quantity and use basis_quantity and billed_quantity

### DIFF
--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -82,11 +82,11 @@ module Secretariat
       line_items.each do |line_item|
         if line_item.tax_percent.nil?
           taxes['0'] = Tax.new(tax_percent: BigDecimal(0), tax_category: line_item.tax_category, tax_amount: BigDecimal(0)) if taxes['0'].nil?
-          taxes['0'].base_amount += BigDecimal(line_item.net_amount) * line_item.quantity
+          taxes['0'].base_amount += BigDecimal(line_item.net_amount) * line_item.billed_quantity
         else
           taxes[line_item.tax_percent] = Tax.new(tax_percent: BigDecimal(line_item.tax_percent), tax_category: line_item.tax_category) if taxes[line_item.tax_percent].nil?
           taxes[line_item.tax_percent].tax_amount += BigDecimal(line_item.tax_amount)
-          taxes[line_item.tax_percent].base_amount += BigDecimal(line_item.net_amount) * line_item.quantity
+          taxes[line_item.tax_percent].base_amount += BigDecimal(line_item.net_amount) * line_item.billed_quantity
         end
       end
 
@@ -140,7 +140,7 @@ module Secretariat
         return false
       end
       line_item_sum = line_items.inject(BigDecimal(0)) do |m, item|
-        m + BigDecimal(item.quantity.negative? ? -item.charge_amount : item.charge_amount)
+        m + BigDecimal(item.billed_quantity.negative? ? -item.charge_amount : item.charge_amount)
       end
       if line_item_sum != basis
         @errors << "Line items do not add up to basis amount #{line_item_sum} / #{basis}"


### PR DESCRIPTION
### Summary
This PR introduces `billed_quantity` as the primary quantity attribute on `LineItem` and adds support for `basis_quantity`, which is used when emitting `<ram:BasisQuantity>` in ZUGFeRD/EN-16931 price blocks. These changes improve standards compliance and remove ambiguity between the quantity invoiced vs. the quantity the price is based on.

### Motivation
In EN-16931/ZUGFeRD:

- `BilledQuantity` = quantity actually invoiced
- `BasisQuantity` = the reference quantity for the unit price (BT-149)

Previously, the library used the same attribute (`quantity`) for both concepts, which is semantically incorrect and can trigger business rule warnings in stricter validators or PEPPOL pipelines.

### Changes
- Replaces the internal usage of `quantity` with `billed_quantity`.
- Adds `basis_quantity` and `effective_basis_quantity` (defaults to `1.0`, i.e., price per 1 unit).
- Emits `<ram:BilledQuantity>` from `billed_quantity`.
- Emits `<ram:BasisQuantity>` from `basis_quantity` (when version == 2).
- Updates tax base, monetary summation, and validation logic to use `billed_quantity`.
- Maintains backward compatibility by:
  - mapping `quantity:` → `billed_quantity:` in the initializer
  - providing deprecated `quantity` reader/writer with warnings

### Backward Compatibility
Existing code calling:

```ruby
LineItem.new(quantity: 3)
item.quantity
item.quantity = 5
``` 

will continue to work but emit a deprecation warning. Users are encouraged to migrate to:

```ruby
billed_quantity:
```

### Default Behavior

If `basis_quantity` is not provided, `BasisQuantity` is emitted as `1.0000` in ZUGFeRD 2.x price blocks, which represents the standard `“price per 1 unit”` semantics.

### Validation

Raises `ArgumentError` if `basis_quantity <= 0`.

### Benefits

- Aligns quantity semantics with EN-16931 (BT-129 vs. BT-149)
- Improves validator compatibility
- Enables price models such as:
  - price per 100 units
  - price per kg
  - price per hour while billing days, etc.

### Migration Notes

Users should:
- Prefer `billed_quantity` instead of `quantity`
- Optionally set `basis_quantity` when pricing is not 1:1

### Performance / Risk

The change is fully backward compatible. Only internal references have transitioned to `billed_quantity`.