### PR TITLE
Enable different tax_reason_text per tax

### DIFF
--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -57,8 +57,8 @@ module Secretariat
       @errors
     end
 
-    def tax_reason_text
-      tax_reason || TAX_EXEMPTION_REASONS[tax_category]
+    def tax_reason_text(tax)
+      tax_reason || TAX_EXEMPTION_REASONS[tax.tax_category || tax_category]
     end
 
     def tax_category_code(tax, version: 2)
@@ -283,8 +283,8 @@ module Secretariat
                 xml['ram'].ApplicableTradeTax do
                   Helpers.currency_element(xml, 'ram', 'CalculatedAmount', tax.tax_amount, currency_code, add_currency: version == 1)
                   xml['ram'].TypeCode 'VAT'
-                  if tax_reason_text.present?
-                    xml['ram'].ExemptionReason tax_reason_text
+                  if tax_reason_text(tax).present?
+                    xml['ram'].ExemptionReason tax_reason_text(tax)
                   end
                   Helpers.currency_element(xml, 'ram', 'BasisAmount', tax.base_amount, currency_code, add_currency: version == 1)
                   xml['ram'].CategoryCode tax_category_code(tax, version: version)


### PR DESCRIPTION
### Summary
This PR updates `tax_reason_text` to accept a `tax` object and determine the exemption reason using the tax line’s `tax_category`, falling back to the invoice-level `tax_category` if necessary. This ensures that exemption reasons are correctly resolved on a per-tax-line basis, especially when multiple tax categories are present on the same invoice.

### Motivation
Previously, `tax_reason_text` did not receive contextual information about the current tax line and relied solely on the invoice-level `tax_category`. This behavior can cause incorrect exemption reason mapping in scenarios where:

- multiple `ApplicableTradeTax` entries exist with different categories, or
- the invoice-level category differs from individual tax entries.

As a result, invoices could emit the wrong `<ram:ExemptionReason>` value.

### Changes
- Modified `tax_reason_text` to accept a `tax` parameter.
- Resolved exemption reason based on `tax.tax_category` first, falling back to the invoice-level `tax_category`.
- Updated `<ram:ExemptionReason>` emission to use the tax-contextualized lookup.

```ruby
def tax_reason_text(tax)
  tax_reason || TAX_EXEMPTION_REASONS[tax.tax_category || tax_category]
end
```

### Benefits
- Correct `<ram:ExemptionReason>` resolution for each tax line.
- Fixes incorrect exemption reasons when multiple tax categories exist.
- Aligns closer with EN-16931 semantics where exemption applies at the line tax level.
- Improves interoperability with stricter validators (e.g., PEPPOL BIS).

### Backward Compatibility
This change is backward compatible:
- Existing behavior is preserved when invoices contain only one tax category.
- Invoices without a defined `tax_reason` continue to fallback gracefully.
- No structural changes to XML output beyond correctness improvements.

### Testing / Validation
Recommended cases covered by this behavior:
- Invoice with only one tax category (unchanged output)
- Invoice with multiple tax categories and distinct exemption reasons
- Invoice with no `tax_reason` set, but a known exemption mapping available

### Performance / Risk

Low risk — the change introduces no new state and affects only lookup logic. XML structure, tags, and attributes remain unchanged; only the exemption reason text becomes contextually accurate.